### PR TITLE
MRF-80877/ try to avoid intermittent issues when deploying artifacts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM maven:3.5.3
+FROM maven:3.5.4
 
 RUN \
       apt-get update \


### PR DESCRIPTION
It could be maven or partial build plugin (no new release, and not any issue that I can found)

More info https://stackoverflow.com/questions/43960518/the-timestamp-in-snapshot-jars-maven-metadata-xml-is-more-than-a-second-than-th